### PR TITLE
http_server: add rest_json and static filesystem resource types

### DIFF
--- a/include/zephyr/net/http/server.h
+++ b/include/zephyr/net/http/server.h
@@ -29,6 +29,7 @@
 
 enum http_resource_type {
 	HTTP_RESOURCE_TYPE_STATIC,
+	HTTP_RESOURCE_TYPE_STATIC_FS,
 	HTTP_RESOURCE_TYPE_DYNAMIC,
 	HTTP_RESOURCE_TYPE_REST,
 	HTTP_RESOURCE_TYPE_REST_JSON
@@ -47,6 +48,11 @@ struct http_resource_detail_static {
 	struct http_resource_detail common;
 	const void *static_data;
 	size_t static_data_len;
+};
+
+struct http_resource_detail_static_fs {
+	struct http_resource_detail common;
+	const char *path;
 };
 
 struct http_client_ctx;


### PR DESCRIPTION
This PR adds a rest json resource type that passes the parsed json to the handler, and a file system resource that delivers static gzipped files from a file system to the http client without having to define each file individually.